### PR TITLE
feat: Add custom User-Agent header to Flight SQL JDBC driver

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "java.compile.nullAnalysis.mode": "disabled"
+}

--- a/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/utils/ArrowFlightConnectionConfigImpl.java
+++ b/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/utils/ArrowFlightConnectionConfigImpl.java
@@ -208,6 +208,10 @@ public final class ArrowFlightConnectionConfigImpl extends ConnectionConfigImpl 
             headers.put(key.toString(), val.toString());
           }
         });
+
+    // Add User-Agent header (using custom name to avoid conflicts with gRPC/Netty)
+    headers.put("x-arrow-user-agent", UserAgentUtils.getUserAgentString());
+
     return headers;
   }
 

--- a/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/utils/UserAgentUtils.java
+++ b/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/utils/UserAgentUtils.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.arrow.driver.jdbc.utils;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
+import java.util.Properties;
+import org.apache.arrow.util.VisibleForTesting;
+
+/** Utility class for generating UserAgent header information. */
+public final class UserAgentUtils {
+  private static final String UNKNOWN = "unknown";
+  private static final String USER_AGENT_FORMAT = "ArrowFlightJDBC/%s (%s; %s; %s)";
+
+  // Cache the driver version to avoid creating a new driver instance each time
+  private static String cachedDriverVersion = null;
+
+  // Application name that can be set by client applications
+  private static String applicationName = null;
+
+  private UserAgentUtils() {
+    // Utility class should not be instantiated
+  }
+
+  /**
+   * Builds a UserAgent string containing client, OS, OSVersion, and Driver version information.
+   *
+   * @return A formatted UserAgent string
+   */
+  public static String getUserAgentString() {
+    String driverVersion = getDriverVersion();
+    String osInfo = getOsInfo();
+    String clientInfo = getClientInfo();
+
+    return String.format(USER_AGENT_FORMAT, driverVersion, osInfo, getJavaVersion(), clientInfo);
+  }
+
+  /**
+   * Sets the application name to be included in the UserAgent string. This can be called by client
+   * applications to identify themselves.
+   *
+   * @param appName The application name
+   */
+  public static void setApplicationName(String appName) {
+    applicationName = appName;
+  }
+
+  /**
+   * Gets the client application name if set, otherwise returns "unknown".
+   *
+   * @return The client application name
+   */
+  private static String getClientInfo() {
+    return applicationName != null ? applicationName : UNKNOWN;
+  }
+
+  /**
+   * Gets the driver version from flight.properties.
+   *
+   * @return The driver version string or "unknown" if not available
+   */
+  private static String getDriverVersion() {
+    if (cachedDriverVersion != null) {
+      return cachedDriverVersion;
+    }
+
+    try {
+      // Load version directly from properties file to avoid creating a driver instance
+      try (InputStream flightPropertiesStream =
+          UserAgentUtils.class.getResourceAsStream("/properties/flight.properties")) {
+        if (flightPropertiesStream != null) {
+          Properties properties = new Properties();
+          try (Reader reader =
+              new BufferedReader(
+                  new InputStreamReader(flightPropertiesStream, StandardCharsets.UTF_8))) {
+            properties.load(reader);
+            cachedDriverVersion =
+                properties.getProperty("org.apache.arrow.flight.jdbc-driver.version", UNKNOWN);
+            return cachedDriverVersion;
+          }
+        }
+      }
+      return UNKNOWN;
+    } catch (IOException e) {
+      return UNKNOWN;
+    }
+  }
+
+  /**
+   * Gets the OS name, version and architecture.
+   *
+   * @return A string containing OS name, version and architecture
+   */
+  private static String getOsInfo() {
+    String osName = System.getProperty("os.name", UNKNOWN);
+    String osVersion = System.getProperty("os.version", UNKNOWN);
+    String osArch = System.getProperty("os.arch", UNKNOWN);
+    return osName + " " + osVersion + " (" + osArch + ")";
+  }
+
+  /**
+   * Gets the Java version.
+   *
+   * @return The Java version string
+   */
+  private static String getJavaVersion() {
+    return "Java " + System.getProperty("java.version", UNKNOWN);
+  }
+
+  /** Resets the cached driver version. Used for testing. */
+  @VisibleForTesting
+  static void resetCachedDriverVersion() {
+    cachedDriverVersion = null;
+  }
+}

--- a/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/utils/UserAgentUtilsTest.java
+++ b/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/utils/UserAgentUtilsTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.arrow.driver.jdbc.utils;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+/** Tests for {@link UserAgentUtils}. */
+public class UserAgentUtilsTest {
+
+  @Test
+  public void testGetUserAgentString() {
+    String userAgent = UserAgentUtils.getUserAgentString();
+
+    // Verify the user agent string is not null
+    assertNotNull(userAgent);
+
+    // Verify it contains the expected format elements
+    assertTrue(userAgent.startsWith("ArrowFlightJDBC/"), "Should start with ArrowFlightJDBC/");
+
+    // Verify it contains OS information
+    String osName = System.getProperty("os.name");
+    assertTrue(userAgent.contains(osName), "Should contain OS name: " + osName);
+
+    // Verify it contains Java version
+    assertTrue(userAgent.contains("Java "), "Should contain Java version");
+  }
+
+  @Test
+  public void testSetApplicationName() {
+    // Reset cached driver version to ensure a clean test
+    UserAgentUtils.resetCachedDriverVersion();
+
+    // Set application name
+    String testAppName = "TestApplication";
+    UserAgentUtils.setApplicationName(testAppName);
+
+    // Get user agent string and verify it contains the application name
+    String userAgent = UserAgentUtils.getUserAgentString();
+    assertTrue(userAgent.contains(testAppName), "Should contain application name: " + testAppName);
+
+    // Reset application name for other tests
+    UserAgentUtils.setApplicationName(null);
+  }
+}


### PR DESCRIPTION
## Summary

This PR adds support for custom User-Agent headers in the Flight SQL JDBC driver.

## Changes

- Added custom User-Agent header functionality to Flight SQL JDBC driver
- Ensures proper identification of client applications when connecting to Flight SQL servers

## Purpose

This enhancement allows applications using the Flight SQL JDBC driver to:
- Set custom User-Agent headers for better client identification
- Improve debugging and monitoring capabilities on the server side
- Follow standard HTTP practices for client identification

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests verified
- [ ] Manual testing completed

## Notes

This PR is created on my personal fork for colleague review before potential submission to the upstream Apache Arrow repository.

---

**Ready for Review** 🔍

Please review the changes and provide feedback. Once approved here, we can consider submitting this to the upstream Apache Arrow project.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author